### PR TITLE
Update weight table styling for print

### DIFF
--- a/script.js
+++ b/script.js
@@ -399,7 +399,8 @@ function calculateRoute() {
     <th>${Math.floor(mins / 60)}h ${mins % 60}m</th>
     <th>${initialFuel}</th><th>${finalDestinationFuel}</th><th>-</th>
   </tr></table>`;
-  let weightTable = '<table class="weight-table"><thead><tr><th></th>';
+  let weightTable =
+    '<table class="weight-table tableizer-table"><thead><tr><th></th>';
   legWeights.forEach((_, idx) => {
     weightTable += `<th>Leg ${idx + 1}</th>`;
   });


### PR DESCRIPTION
## Summary
- ensure the leg weight table uses the same `tableizer-table` styling as the printable flight log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874fa450d948321a8beb4dfb876a746