### PR TITLE
Add pilot search autocomplete

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,12 +40,18 @@
 
     <!-- Crew + baggage -->
     <div>
-      <label for="leftPilot">Left Pilot:</label>
-      <input id="leftPilot" list="pilot-options" />
+      <div class="pilot-search">
+        <label for="leftPilot">Left Pilot:</label>
+        <input id="leftPilot" autocomplete="off" />
+        <div class="pilot-results" id="leftPilot-results"></div>
+      </div>
 
-      <label for="rightPilot">Right Pilot:</label>
-      <input id="rightPilot" list="pilot-options" />
-      <datalist id="pilot-options"></datalist>
+      <div class="pilot-search">
+        <label for="rightPilot">Right Pilot:</label>
+        <input id="rightPilot" autocomplete="off" />
+        <div class="pilot-results" id="rightPilot-results"></div>
+      </div>
+
 
       <label for="baggage">Baggage (kg):</label>
       <input type="number" id="baggage" style="width: 50px" />

--- a/script.js
+++ b/script.js
@@ -16,14 +16,6 @@ function populateHelicopterDropdown() {
   });
 }
 function populatePilotDropdowns() {
-  const datalist = document.getElementById("pilot-options");
-  if (!datalist) return;
-  datalist.innerHTML = "";
-  PILOTS.forEach((pilot) => {
-    const opt = document.createElement("option");
-    opt.value = pilot.name;
-    datalist.appendChild(opt);
-  });
   document.getElementById("leftPilot").value = "";
   document.getElementById("rightPilot").value = "";
 }
@@ -82,12 +74,49 @@ function disableDuplicatePilot(e) {
     }
   }
 }
+
+function setupPilotSearch(id) {
+  const input = document.getElementById(id);
+  const results = document.getElementById(id + "-results");
+  if (!input || !results) return;
+
+  function hide() {
+    results.style.display = "none";
+  }
+
+  function show() {
+    const term = input.value.toLowerCase();
+    results.innerHTML = "";
+    const matches = PILOTS.filter((p) =>
+      p.name.toLowerCase().includes(term),
+    );
+    matches.forEach((p) => {
+      const div = document.createElement("div");
+      div.className = "result-item";
+      div.textContent = p.name;
+      div.addEventListener("mousedown", () => {
+        input.value = p.name;
+        hide();
+        disableDuplicatePilot({ target: input });
+      });
+      results.appendChild(div);
+    });
+    results.style.display = matches.length ? "block" : "none";
+  }
+
+  input.addEventListener("input", show);
+  input.addEventListener("focus", show);
+  document.addEventListener("click", (e) => {
+    if (!results.contains(e.target) && e.target !== input) hide();
+  });
+}
 document
   .getElementById("leftPilot")
   .addEventListener("input", disableDuplicatePilot);
 document
   .getElementById("rightPilot")
   .addEventListener("input", disableDuplicatePilot);
+["leftPilot", "rightPilot"].forEach((id) => setupPilotSearch(id));
 ["seat1a", "seat2a", "seat1c"].forEach((id) => {
   document.getElementById(id).addEventListener("change", disableDuplicateMedic);
 });

--- a/style.css
+++ b/style.css
@@ -25,6 +25,33 @@ button {
   vertical-align: middle;
 }
 
+.pilot-search {
+  position: relative;
+  display: inline-block;
+}
+
+.pilot-results {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  z-index: 10;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.pilot-results .result-item {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.pilot-results .result-item:hover {
+  background-color: #eee;
+}
+
 select,
 input,
 button {


### PR DESCRIPTION
## Summary
- replace pilot dropdown with search autocomplete fields
- show suggestions as user types or focuses field
- style new search result dropdowns

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6875a983cca08321bd043fad31192809