### PR TITLE
Fix search dropdown alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,14 +42,18 @@
     <div>
       <div class="pilot-search">
         <label for="leftPilot">Left Pilot:</label>
-        <input id="leftPilot" autocomplete="off" />
-        <div class="pilot-results" id="leftPilot-results"></div>
+        <div class="input-wrapper">
+          <input id="leftPilot" autocomplete="off" />
+          <div class="pilot-results" id="leftPilot-results"></div>
+        </div>
       </div>
 
       <div class="pilot-search">
         <label for="rightPilot">Right Pilot:</label>
-        <input id="rightPilot" autocomplete="off" />
-        <div class="pilot-results" id="rightPilot-results"></div>
+        <div class="input-wrapper">
+          <input id="rightPilot" autocomplete="off" />
+          <div class="pilot-results" id="rightPilot-results"></div>
+        </div>
       </div>
 
 
@@ -59,23 +63,29 @@
 
     <!-- Seat Assignments -->
     <div>
-      <div class="pilot-search">
-        <label for="seat1a">Seat 1A:</label>
-        <input id="seat1a" autocomplete="off" />
-        <div class="pilot-results" id="seat1a-results"></div>
-      </div>
+        <div class="pilot-search">
+          <label for="seat1a">Seat 1A:</label>
+          <div class="input-wrapper">
+            <input id="seat1a" autocomplete="off" />
+            <div class="pilot-results" id="seat1a-results"></div>
+          </div>
+        </div>
 
-      <div class="pilot-search">
-        <label for="seat2a">Seat 2A:</label>
-        <input id="seat2a" autocomplete="off" />
-        <div class="pilot-results" id="seat2a-results"></div>
-      </div>
+        <div class="pilot-search">
+          <label for="seat2a">Seat 2A:</label>
+          <div class="input-wrapper">
+            <input id="seat2a" autocomplete="off" />
+            <div class="pilot-results" id="seat2a-results"></div>
+          </div>
+        </div>
 
-      <div class="pilot-search">
-        <label for="seat1c">Seat 1C:</label>
-        <input id="seat1c" autocomplete="off" />
-        <div class="pilot-results" id="seat1c-results"></div>
-      </div>
+        <div class="pilot-search">
+          <label for="seat1c">Seat 1C:</label>
+          <div class="input-wrapper">
+            <input id="seat1c" autocomplete="off" />
+            <div class="pilot-results" id="seat1c-results"></div>
+          </div>
+        </div>
     </div>
 
     <!-- Config: Patient, Escort, Speed, Burn -->

--- a/style.css
+++ b/style.css
@@ -34,12 +34,17 @@ button {
   width: 100px;
 }
 
+.input-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .pilot-results {
   display: none;
   position: absolute;
   top: 100%;
   left: 0;
-  width: 100px;
+  width: 100%;
   background-color: #fff;
   border: 1px solid #ccc;
   z-index: 10;


### PR DESCRIPTION
## Summary
- wrap pilot input boxes in a new `.input-wrapper`
- style `.input-wrapper` and adjust `.pilot-results` so search results appear directly beneath their inputs

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6876ee0019c48321bbe674e9c3776054