### PR TITLE
Fix fonts for search results and print

### DIFF
--- a/script.js
+++ b/script.js
@@ -798,7 +798,7 @@ function printFlightLog() {
       table.tableizer-table { 
       font-size: 8px; border: 
       1px solid #CCC; 
-      font-family: Arial, Helvetica, sans-serif;
+      font-family: "Roboto", Arial, Helvetica, sans-serif;
       table-layout: fixed;
       border-collapse: collapse;
       border-spacing: 0; 

--- a/style.css
+++ b/style.css
@@ -48,6 +48,14 @@ button {
   cursor: pointer;
 }
 
+/* Ensure autocomplete results use the page font */
+.pilot-results,
+.pilot-results .result-item,
+.waypoint-results,
+.waypoint-results .result-item {
+  font-family: inherit;
+}
+
 .pilot-results .result-item:hover {
   background-color: #eee;
 }


### PR DESCRIPTION
## Summary
- ensure auto-complete result lists inherit the page font
- use Roboto font when printing the flight log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876f6e198148321946d567189e5ebd0