### PR TITLE
Match route table style to flight plan

### DIFF
--- a/script.js
+++ b/script.js
@@ -389,7 +389,7 @@ function calculateRoute() {
     totalFuel = 0,
     lastWeight = 0;
   let table = `
-<table>
+<table class="tableizer-table">
   <thead>
     <tr>
       <th rowspan="2">Leg</th>

--- a/style.css
+++ b/style.css
@@ -158,3 +158,33 @@ th {
 #weightTable table.weight-table td:not(:first-child) {
   width: 45px;
 }
+
+/* Match flight plan styling */
+table.tableizer-table {
+  font-size: 8px;
+  border: 1px solid #ccc;
+  font-family: "Roboto", Arial, Helvetica, sans-serif;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.tableizer-table th,
+.tableizer-table td {
+  border: 1px solid #000;
+  padding: 4px;
+  margin: 0;
+  font-weight: normal !important;
+  text-align: center;
+}
+
+.tableizer-table th {
+  background-color: #fff;
+  color: #000;
+}
+
+.spacer {
+  border: none;
+  visibility: hidden;
+  padding: 0;
+}


### PR DESCRIPTION
## Summary
- use the same table styling for calculated route as the flight plan
- add `.tableizer-table` CSS class to reuse flight plan styles

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68770752e4fc8321bdabb7fed4fa3ba1