### PR TITLE
Enable automatic route calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Planner
 
-This project provides a simple helicopter route planner. Open `index.html` in a web browser to use it.
+This project provides a simple helicopter route planner. Open `index.html` in a
+web browser to use it. The route updates automatically whenever you change any
+inputs, so there's no longer a separate calculate button.

--- a/index.html
+++ b/index.html
@@ -170,7 +170,6 @@
     </div>
     <div style="margin-top: 10px">
       <button onclick="addLeg()">Add Leg</button>
-      <button onclick="calculateRoute()">Calculate Route</button>
       <button onclick="openForeFlight()">Open Foreflight</button>
       <button onclick="openSkyVector()">Open SkyVector</button>
       <button onclick="getWeather()">Get Weather</button>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 let latestLegWeights = [];
 let latestWeightTable = "";
 let currentWaypointCodes = [];
+let autoCalcTimer;
 
 function populateHelicopterDropdown() {
   const heliSelect = document.getElementById("helicopter");
@@ -266,6 +267,7 @@ function attachRemoveHandler(row) {
         r.querySelector("label").textContent = `Leg ${idx + 1}:`;
       });
     }
+    scheduleAutoCalculate();
   });
 }
 function addLeg() {
@@ -334,6 +336,23 @@ function addLeg() {
     from.value = `${code}-${waypoints[code].name}`;
   }
   attachRemoveHandler(newRow);
+  setupAutoCalculate(newRow);
+  scheduleAutoCalculate();
+}
+
+function scheduleAutoCalculate() {
+  clearTimeout(autoCalcTimer);
+  autoCalcTimer = setTimeout(calculateRoute, 300);
+}
+
+function setupAutoCalculate(container = document) {
+  container.querySelectorAll('input, select').forEach((el) => {
+    if (!el.dataset.autoCalc) {
+      el.addEventListener('input', scheduleAutoCalculate);
+      el.addEventListener('change', scheduleAutoCalculate);
+      el.dataset.autoCalc = '1';
+    }
+  });
 }
 function haversine(lat1, lon1, lat2, lon2) {
   const R = 6371;
@@ -870,3 +889,5 @@ populateAllDropdowns();
 disableDuplicatePilot();
 populateHelicopterDropdown();
 document.querySelectorAll(".leg-row").forEach(attachRemoveHandler);
+setupAutoCalculate();
+calculateRoute();


### PR DESCRIPTION
## Summary
- remove manual Calculate Route button
- automatically calculate route whenever inputs change
- document auto-calculation behaviour

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687777d7e0a083219d4aad31c809ec98