### PR TITLE
Remove spacing between flight log tables

### DIFF
--- a/script.js
+++ b/script.js
@@ -872,7 +872,6 @@ function printFlightLog() {
     }
     </style>
     ${infoTable}
-    <br>
     ${legsTable}
     ${routeSection}
     ${weightSection}`;


### PR DESCRIPTION
## Summary
- print flight log with no extra break between info and legs tables

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878f0fe8f2c8321b6b2e70ccbe99492