### PR TITLE
Align print layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -882,6 +882,7 @@ function printFlightLog() {
     .weight-table {
       font-size: 12px;
       width: auto;
+      margin: 20px 0;
     }
     .weight-table th,
     .weight-table td {
@@ -899,8 +900,8 @@ function printFlightLog() {
     ${infoTable}
     ${legsTable}
     <div class="print-row">
-      ${routeSection}
       ${weightSection}
+      ${routeSection}
     </div>`;
   const win = window.open("", "_blank");
   win.document.write(html);


### PR DESCRIPTION
## Summary
- make weight table print to left of route
- left-align the weight table

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687920348a6483218177068ea6f16e01