### PR TITLE
Adjust gap for tables in flight log printout

### DIFF
--- a/script.js
+++ b/script.js
@@ -874,7 +874,7 @@ function printFlightLog() {
     }
     .print-row {
       display: flex;
-      gap: 20px;
+      gap: 0;
       align-items: flex-start;
     }
     .route-section { flex: 2; }


### PR DESCRIPTION
## Summary
- tweak the CSS so weight and route tables touch when printing a flight log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68792ac488d4832183a8cb4356379dfa