### PR TITLE
Add management page for pilots/medics/waypoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@
       <button onclick="getWeather()">Get Weather</button>
       <button onclick="composeEmail()">Compose Email</button>
       <button onclick="printFlightLog()">Print Flight Log</button>
+      <button onclick="window.location.href='manage.html'">Manage Data</button>
 
       <div id="result"></div>
       <div id="weightTable"></div>

--- a/manage.html
+++ b/manage.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Manage Data</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>Manage Data</h1>
+
+    <section>
+      <h2>Add Pilot</h2>
+      <input id="pilotName" placeholder="Name" />
+      <input id="pilotWeight" type="number" placeholder="Weight (kg)" />
+      <button onclick="addPilot()">Save Pilot</button>
+    </section>
+
+    <section>
+      <h2>Add Medic</h2>
+      <input id="medicName" placeholder="Name" />
+      <input id="medicWeight" type="number" placeholder="Weight (kg)" />
+      <button onclick="addMedic()">Save Medic</button>
+    </section>
+
+    <section>
+      <h2>Add Waypoint</h2>
+      <input id="waypointCode" placeholder="Code" />
+      <input id="waypointName" placeholder="Name" />
+      <input id="waypointRegion" placeholder="Region(s)" />
+      <input id="waypointLat" type="number" step="0.0001" placeholder="Lat" />
+      <input id="waypointLon" type="number" step="0.0001" placeholder="Lon" />
+      <button onclick="addWaypoint()">Save Waypoint</button>
+    </section>
+
+    <button onclick="window.location.href='index.html'">Back</button>
+
+    <script src="manage.js"></script>
+  </body>
+</html>

--- a/manage.js
+++ b/manage.js
@@ -1,0 +1,51 @@
+function addPilot() {
+  const name = document.getElementById('pilotName').value.trim();
+  const weight = parseFloat(document.getElementById('pilotWeight').value);
+  if (!name || isNaN(weight)) {
+    alert('Please enter a name and weight');
+    return;
+  }
+  const pilots = JSON.parse(localStorage.getItem('PILOTS_EXTRA') || '[]');
+  pilots.push({ name, weight });
+  localStorage.setItem('PILOTS_EXTRA', JSON.stringify(pilots));
+  document.getElementById('pilotName').value = '';
+  document.getElementById('pilotWeight').value = '';
+  alert('Pilot saved');
+}
+
+function addMedic() {
+  const name = document.getElementById('medicName').value.trim();
+  const weight = parseFloat(document.getElementById('medicWeight').value);
+  if (!name || isNaN(weight)) {
+    alert('Please enter a name and weight');
+    return;
+  }
+  const medics = JSON.parse(localStorage.getItem('MEDICS_EXTRA') || '[]');
+  medics.push({ name, weight });
+  localStorage.setItem('MEDICS_EXTRA', JSON.stringify(medics));
+  document.getElementById('medicName').value = '';
+  document.getElementById('medicWeight').value = '';
+  alert('Medic saved');
+}
+
+function addWaypoint() {
+  const code = document.getElementById('waypointCode').value.trim();
+  const name = document.getElementById('waypointName').value.trim();
+  const regionText = document.getElementById('waypointRegion').value.trim();
+  const lat = parseFloat(document.getElementById('waypointLat').value);
+  const lon = parseFloat(document.getElementById('waypointLon').value);
+  if (!code || !name || !regionText || isNaN(lat) || isNaN(lon)) {
+    alert('Please fill out all waypoint fields');
+    return;
+  }
+  const regions = regionText.split(',').map(r => r.trim());
+  const wpts = JSON.parse(localStorage.getItem('WAYPOINTS_EXTRA') || '[]');
+  wpts.push({ code, name, regions, lat, lon });
+  localStorage.setItem('WAYPOINTS_EXTRA', JSON.stringify(wpts));
+  document.getElementById('waypointCode').value = '';
+  document.getElementById('waypointName').value = '';
+  document.getElementById('waypointRegion').value = '';
+  document.getElementById('waypointLat').value = '';
+  document.getElementById('waypointLon').value = '';
+  alert('Waypoint saved');
+}

--- a/script.js
+++ b/script.js
@@ -3,6 +3,23 @@ let latestWeightTable = "";
 let latestRouteTable = "";
 let currentWaypointCodes = [];
 
+function loadExtraData() {
+  try {
+    const p = JSON.parse(localStorage.getItem("PILOTS_EXTRA") || "[]");
+    const m = JSON.parse(localStorage.getItem("MEDICS_EXTRA") || "[]");
+    const w = JSON.parse(localStorage.getItem("WAYPOINTS_EXTRA") || "[]");
+    p.forEach((o) => PILOTS.push(o));
+    m.forEach((o) => MEDICS.push(o));
+    w.forEach((o) => {
+      if (o.code) {
+        waypoints[o.code] = { name: o.name, regions: o.regions, lat: o.lat, lon: o.lon };
+      }
+    });
+  } catch(e) {
+    console.error(e);
+  }
+}
+
 function populateHelicopterDropdown() {
   const heliSelect = document.getElementById("helicopter");
   heliSelect.innerHTML = "";
@@ -908,6 +925,7 @@ function printFlightLog() {
   win.document.close();
   win.print();
 }
+loadExtraData();
 populatePilotDropdowns();
 populateAllDropdowns();
 disableDuplicatePilot();


### PR DESCRIPTION
## Summary
- add page to manage additional pilots, medics and waypoints
- store extra data in localStorage so planner can use them
- load extra data into arrays when planner starts
- add button from planner to new management page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6879503fdd8883219222cd22c8c251ac